### PR TITLE
Changed 'acc' to 'accuracy' in ./model/damage_classification.py. 

### DIFF
--- a/model/damage_classification.py
+++ b/model/damage_classification.py
@@ -168,7 +168,7 @@ def train_model(train_data, train_csv, test_data, test_csv, model_in, model_out)
 
     
     #Filepath to save model weights
-    filepath = model_out + "-saved-model-{epoch:02d}-{acc:.2f}.hdf5"
+    filepath = model_out + "-saved-model-{epoch:02d}-{accuracy:.2f}.hdf5"
     checkpoints = keras.callbacks.ModelCheckpoint(filepath,
                                                     monitor=['loss', 'accuracy'],
                                                     verbose=1,


### PR DESCRIPTION
This updates the model filename string (L171) to work consistently with keras ModelCheckpoint formatter to save out based on the accuracy number